### PR TITLE
Add PyCon JP Association

### DIFF
--- a/README.md
+++ b/README.md
@@ -2113,3 +2113,7 @@ https://github.com/nhatnguyen2410/w3band-frondend-project
 ### Database project management
 Distributed database material management
 https://github.com/nhatnguyen2410/QLVT
+
+### PyCon JP Association
+The PyCon JP Association (Japanese: 一般社団法人PyCon JP Association) is a nonprofit organization for Python users in Japan, to promote Python and supports its development. Further it is our goal to hold an annual PyCon JP conference.
+https://www.pycon.jp/


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
https://pyconjp.1password.com/

#### Project Name ####
PyCon JP Association

#### Short Description ####
The PyCon JP Association (Japanese: 一般社団法人PyCon JP Association) is a nonprofit organization for Python users in Japan, to promote Python and supports its development. Further it is our goal to hold an annual PyCon JP conference.

#### Project Age ####
9 years

#### Number Of Core Contributors ####
12 (5 Board Bembers and 7 Administrative Members)

#### Project Website ####
* https://www.pycon.jp/index.html
* https://www.pycon.jp/committee/english.html

#### Repository URL(s) ####
https://github.com/pyconjp/

#### Latest Release URL(s) ####
https://2022.pycon.jp/en/

#### License Type ####
CC BY 4.0

#### License URL ####
https://www.pycon.jp/committee/license.html

## A Bit About Yourself  ##

#### Name ####
Takanori Suzuki

#### Email ####
takanori@pycon.jp

#### Project Role ####
Vice-Chair

#### Profile/Website ####
https://www.pycon.jp/committee/english.html#takanori-suzuki

#### Comments ####
